### PR TITLE
Remove genmesh/obj

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## Version 0.4.2
+- Remove dependency on `genmesh` and `obj` crates
+
 ## Version 0.4.1 (2019-12-17)
 - Fix bug in shadow mapping on Intel GPUs ([#12](https://github.com/leod/rendology/pull/12))
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,6 @@ readme = "README.md"
 nalgebra = "0.18"
 glium = "0.25"
 log = "0.4"
-obj = { version = "0.9", features = ["genmesh"] }
-genmesh = "0.6"
 glsl = "3.0"
 num-traits = "0.2"
 num-derive = "0.3"

--- a/src/basic_obj/mesh.rs
+++ b/src/basic_obj/mesh.rs
@@ -1,9 +1,5 @@
-use std::path::Path;
-
-use log::info;
-
 use crate::basic_obj::{BasicObj, Vertex};
-use crate::mesh::{IndexBuffer, Mesh};
+use crate::mesh::Mesh;
 use crate::CreationError;
 
 pub fn mesh_from_slices<F: glium::backend::Facade>(
@@ -23,51 +19,6 @@ pub fn mesh_from_slices<F: glium::backend::Facade>(
         .collect::<Vec<_>>();
 
     Mesh::create_with_indices(facade, primitive_type, &vertices, indices)
-}
-
-pub fn load_wavefront<F: glium::backend::Facade>(
-    facade: &F,
-    path: &Path,
-) -> Result<Mesh<Vertex>, CreationError> {
-    info!("Loading Wavefront .OBJ file: `{}'", path.display());
-
-    // As in:
-    // https://github.com/glium/glium/blob/master/examples/support/mod.rs
-
-    let data = obj::Obj::load(path).unwrap();
-
-    let mut vertices = Vec::new();
-
-    for object in data.objects.iter() {
-        for polygon in object.groups.iter().flat_map(|g| g.polys.iter()) {
-            match polygon {
-                genmesh::Polygon::PolyTri(genmesh::Triangle {
-                    x: v1,
-                    y: v2,
-                    z: v3,
-                }) => {
-                    for v in [v1, v2, v3].iter() {
-                        let position = data.position[v.0];
-                        let normal = v.2.map(|index| data.normal[index]);
-
-                        let normal = normal.unwrap_or([0.0, 0.0, 0.0]);
-
-                        vertices.push(Vertex { position, normal })
-                    }
-                }
-                _ => unimplemented!(),
-            }
-        }
-    }
-
-    let vertex_buffer = glium::VertexBuffer::new(facade, &vertices).unwrap();
-    let primitive_type = glium::index::PrimitiveType::TrianglesList;
-    let index_buffer = IndexBuffer::NoIndices(glium::index::NoIndices(primitive_type));
-
-    Ok(Mesh {
-        vertex_buffer,
-        index_buffer,
-    })
 }
 
 #[rustfmt::skip]

--- a/src/basic_obj/mod.rs
+++ b/src/basic_obj/mod.rs
@@ -9,7 +9,7 @@ use num_traits::{FromPrimitive, ToPrimitive};
 use crate::shader::{InstanceInput, InstancingMode, ToUniforms};
 use crate::{CreationError, DrawError, Drawable, Mesh};
 
-pub use mesh::{load_wavefront, mesh_from_slices, CUBE_INDICES, CUBE_NORMALS, CUBE_POSITIONS};
+pub use mesh::{mesh_from_slices, CUBE_INDICES, CUBE_NORMALS, CUBE_POSITIONS};
 pub use scene::{Core, Instance};
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, num_derive::FromPrimitive, num_derive::ToPrimitive)]

--- a/src/instancing.rs
+++ b/src/instancing.rs
@@ -47,7 +47,7 @@ where
         let range = start_index..start_index + num_to_write;
 
         // Safe to unwrap since we have bounded the range to our capacity.
-        let slice = self.buffer.slice_mut(range.clone()).unwrap();
+        let slice = self.buffer.slice_mut(range).unwrap();
         slice.write(&vertices[0..num_to_write]);
 
         self.num_used += num_to_write;


### PR DESCRIPTION
We may need to reintroduce them later, but in a better place than `basic_obj`. For now, they are unused.