### PR TITLE
Use fragment core for shadow map shader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 ## Version 0.4.2
 - Remove dependency on `genmesh` and `obj` crates ([#14](https://github.com/leod/rendology/pull/14))
+- Base shadow map core on given fragment core ([#15](https://github.com/leod/rendology/pull/15))
 
 ## Version 0.4.1 (2019-12-17)
 - Fix bug in shadow mapping on Intel GPUs ([#12](https://github.com/leod/rendology/pull/12))


### PR DESCRIPTION
This allows users to `discard` in fragment shaders in their scene core without getting wrong shadows.