### PR TITLE
Move associated types of SceneCore into new trait CoreInput

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
-## Version 0.4.2
+## Version 0.5.0
 - Remove dependency on `genmesh` and `obj` crates ([#14](https://github.com/leod/rendology/pull/14))
 - Base shadow map core on given fragment core ([#15](https://github.com/leod/rendology/pull/15))
+- Move associated types of SceneCore into new trait CoreInput ([#16](https://github.com/leod/rendology/pull/16))
 
 ## Version 0.4.1 (2019-12-17)
 - Fix bug in shadow mapping on Intel GPUs ([#12](https://github.com/leod/rendology/pull/12))

--- a/examples/custom_scene_core.rs
+++ b/examples/custom_scene_core.rs
@@ -15,7 +15,7 @@ const WINDOW_SIZE: (u32, u32) = (1280, 720);
 
 mod my_scene {
     use nalgebra as na;
-    use rendology::{basic_obj, shader, Context, SceneCore, CoreInput};
+    use rendology::{basic_obj, shader, Context, CoreInput, SceneCore};
 
     #[derive(Clone)]
     pub struct Params<'a> {

--- a/examples/custom_scene_core.rs
+++ b/examples/custom_scene_core.rs
@@ -15,7 +15,7 @@ const WINDOW_SIZE: (u32, u32) = (1280, 720);
 
 mod my_scene {
     use nalgebra as na;
-    use rendology::{basic_obj, shader, Context, SceneCore};
+    use rendology::{basic_obj, shader, Context, SceneCore, CoreInput};
 
     #[derive(Clone)]
     pub struct Params<'a> {
@@ -45,11 +45,13 @@ mod my_scene {
 
     pub struct Core;
 
-    impl SceneCore for Core {
+    impl CoreInput for Core {
         type Params = Params<'static>;
         type Instance = Instance;
         type Vertex = basic_obj::Vertex;
+    }
 
+    impl SceneCore for Core {
         fn scene_core(
             &self,
         ) -> shader::Core<(Context, Self::Params), Self::Instance, Self::Vertex> {

--- a/src/basic_obj/scene.rs
+++ b/src/basic_obj/scene.rs
@@ -1,6 +1,6 @@
 use nalgebra as na;
 
-use crate::scene::SceneCore;
+use crate::scene::{CoreInput, SceneCore};
 use crate::{basic_obj, shader, Context};
 
 #[derive(Clone, Debug)]
@@ -28,11 +28,13 @@ impl_instance_input!(
 
 pub struct Core;
 
-impl SceneCore for Core {
+impl CoreInput for Core {
     type Params = ();
     type Instance = Instance;
     type Vertex = basic_obj::Vertex;
+}
 
+impl SceneCore for Core {
     fn scene_core(&self) -> shader::Core<(Context, ()), Instance, basic_obj::Vertex> {
         let vertex = shader::VertexCore::empty()
             .with_out(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ pub mod fxaa;
 pub mod line;
 pub mod pipeline;
 pub mod screen_quad;
+pub mod particles;
 
 pub use basic_obj::BasicObj;
 pub use camera::Camera;
@@ -26,7 +27,7 @@ pub use pipeline::{
     Config, Pipeline, PlainScenePass, ShadedScenePass, ShadedScenePassSetup, ShadowPass,
 };
 pub use render_list::RenderList;
-pub use scene::SceneCore;
+pub use scene::{CoreInput, SceneCore};
 pub use screen_quad::ScreenQuad;
 pub use shader::InstancingMode;
 pub use stage::{Context, Light};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,9 +13,9 @@ mod stage;
 pub mod basic_obj;
 pub mod fxaa;
 pub mod line;
+pub mod particles;
 pub mod pipeline;
 pub mod screen_quad;
-pub mod particles;
 
 pub use basic_obj::BasicObj;
 pub use camera::Camera;

--- a/src/line.rs
+++ b/src/line.rs
@@ -16,7 +16,7 @@ use nalgebra as na;
 
 use glium::implement_vertex;
 
-use crate::{shader, Context, CreationError, Mesh, SceneCore, CoreInput};
+use crate::{shader, Context, CoreInput, CreationError, Mesh, SceneCore};
 
 #[derive(Clone, Debug)]
 pub struct Params {

--- a/src/line.rs
+++ b/src/line.rs
@@ -16,7 +16,7 @@ use nalgebra as na;
 
 use glium::implement_vertex;
 
-use crate::{shader, Context, CreationError, Mesh, SceneCore};
+use crate::{shader, Context, CreationError, Mesh, SceneCore, CoreInput};
 
 #[derive(Clone, Debug)]
 pub struct Params {
@@ -158,11 +158,13 @@ const VERTEX_BODY: &str = "
 
 pub struct Core;
 
-impl SceneCore for Core {
+impl CoreInput for Core {
     type Params = Params;
     type Instance = Instance;
     type Vertex = Point;
+}
 
+impl SceneCore for Core {
     fn scene_core(&self) -> shader::Core<(Context, Params), Instance, Point> {
         let vertex = shader::VertexCore::empty()
             .with_body(VERTEX_BODY)

--- a/src/scene/mod.rs
+++ b/src/scene/mod.rs
@@ -1,10 +1,33 @@
 use crate::shader::{self, InstanceInput, UniformInput};
-use crate::Context;
+use crate::{Context, InstancingMode};
 
-pub trait SceneCore {
+pub trait BuildProgram {
+    fn build_program<F: glium::backend::Facade>(
+        &self,
+        facade: &F,
+        instancing_mode: InstancingMode,
+    ) -> Result<glium::Program, glium::program::ProgramCreationError>;
+}
+
+pub trait CoreInput {
     type Params: UniformInput + Clone;
     type Instance: InstanceInput + Clone;
     type Vertex: glium::vertex::Vertex;
+}
 
-    fn scene_core(&self) -> shader::Core<(Context, Self::Params), Self::Instance, Self::Vertex>;
+pub trait SceneCore: CoreInput {
+    fn scene_core(
+        &self,
+    ) -> shader::Core<(Context, <Self as CoreInput>::Params), <Self as CoreInput>::Instance, <Self as CoreInput>::Vertex>;
+}
+
+impl<T: SceneCore> BuildProgram for T {
+    fn build_program<F: glium::backend::Facade>(
+        &self,
+        facade: &F,
+        instancing_mode: InstancingMode,
+    ) -> Result<glium::Program, glium::program::ProgramCreationError> {
+        // TODO: Dropping error detail here...
+        self.scene_core().build_program(facade, instancing_mode).map_err(|e| e.error)
+    }
 }

--- a/src/scene/mod.rs
+++ b/src/scene/mod.rs
@@ -18,7 +18,11 @@ pub trait CoreInput {
 pub trait SceneCore: CoreInput {
     fn scene_core(
         &self,
-    ) -> shader::Core<(Context, <Self as CoreInput>::Params), <Self as CoreInput>::Instance, <Self as CoreInput>::Vertex>;
+    ) -> shader::Core<
+        (Context, <Self as CoreInput>::Params),
+        <Self as CoreInput>::Instance,
+        <Self as CoreInput>::Vertex,
+    >;
 }
 
 impl<T: SceneCore> BuildProgram for T {
@@ -28,6 +32,8 @@ impl<T: SceneCore> BuildProgram for T {
         instancing_mode: InstancingMode,
     ) -> Result<glium::Program, glium::program::ProgramCreationError> {
         // TODO: Dropping error detail here...
-        self.scene_core().build_program(facade, instancing_mode).map_err(|e| e.error)
+        self.scene_core()
+            .build_program(facade, instancing_mode)
+            .map_err(|e| e.error)
     }
 }


### PR DESCRIPTION
Also: add `BuildProgram` trait. This will allow us to provide plain scene shaders without having to implement `SceneCore`.