### PR TITLE
Performance tuning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Initial implementation of particles ([#17](https://github.com/leod/rendology/pull/17), [#19](https://github.com/leod/rendology/pull/19))
 - Add a shader transform for transparency with dithering ([#20](https://github.com/leod/rendology/pull/20))
 - Change shader compilation so that output assignments can be evaluated before bodies ([#20](https://github.com/leod/rendology/pull/20))
+- Performance tuning ([#21](https://github.com/leod/rendology/pull/21))
 
 ## Version 0.4.1 (2019-12-17)
 - Fix bug in shadow mapping on Intel GPUs ([#12](https://github.com/leod/rendology/pull/12))

--- a/examples/cube.rs
+++ b/examples/cube.rs
@@ -154,7 +154,7 @@ fn scene(time: f32) -> Scene {
 
     scene.lights.push(Light {
         position: na::Point3::new(10.0, 10.0, 10.0),
-        attenuation: na::Vector3::new(1.0, 0.0, 0.0),
+        attenuation: na::Vector4::new(1.0, 0.0, 0.0, 0.0),
         color: na::Vector3::new(1.0, 1.0, 1.0),
         is_main: true,
         ..Default::default()

--- a/examples/custom_scene_core.rs
+++ b/examples/custom_scene_core.rs
@@ -347,7 +347,7 @@ fn scene(time: f32) -> Scene {
 
         scene.lights.push(Light {
             position: orbit_transform.transform_point(&na::Point3::origin()),
-            attenuation: na::Vector3::new(1.0, 6.0, 30.0),
+            attenuation: na::Vector4::new(1.0, 6.0, 30.0, 0.0),
             color: 40.0 * na::Vector3::new(color.x, color.y, color.z),
             is_main: false,
             ..Default::default()
@@ -361,7 +361,7 @@ fn scene(time: f32) -> Scene {
 
     scene.lights.push(Light {
         position: na::Point3::new(1.0, 1.0, 10.0),
-        attenuation: na::Vector3::new(1.0, 0.0, 0.0),
+        attenuation: na::Vector4::new(1.0, 0.0, 0.0, 0.0),
         color: na::Vector3::new(0.02, 0.02, 0.02),
         is_main: true,
         ..Default::default()

--- a/examples/lines.rs
+++ b/examples/lines.rs
@@ -171,7 +171,7 @@ fn scene(time: f32) -> Scene {
 
     scene.lights.push(Light {
         position: na::Point3::new(10.0, 10.0, 10.0),
-        attenuation: na::Vector3::new(1.0, 0.0, 0.0),
+        attenuation: na::Vector4::new(1.0, 0.0, 0.0, 0.0),
         color: na::Vector3::new(1.0, 1.0, 1.0),
         is_main: true,
         ..Default::default()

--- a/examples/particles.rs
+++ b/examples/particles.rs
@@ -97,7 +97,6 @@ impl Pipeline {
 
         let particle_params = particle::Params { time: scene.time };
         let particle_draw_params = glium::DrawParameters {
-            backface_culling: glium::draw_parameters::BackfaceCullingMode::CullClockwise,
             depth: glium::Depth {
                 test: glium::DepthTest::IfLessOrEqual,
                 write: false,
@@ -244,7 +243,7 @@ fn scene(time: f32, dt: f32) -> Scene {
     let x_unit = tangent.cross(&smallest_unit).normalize();
     let y_unit = tangent.cross(&x_unit).normalize();
 
-    let spawn_per_sec = (20000.0 * 30.0) / 3.0;
+    let spawn_per_sec = 20000.0 * 30.0;
 
     for _ in 0..(spawn_per_sec * dt) as usize {
         let radius = rand::random::<f32>() * 1.41;
@@ -256,10 +255,10 @@ fn scene(time: f32, dt: f32) -> Scene {
         let particle = Particle {
             spawn_time: time,
             life_duration: 3.0,
-            start_pos: pos,
-            velocity: velocity * radius,
+            start_pos: pos + velocity * 1.0,
+            velocity,
             color: na::Vector3::new(radius / 2.0, radius / 8.0, 0.0),
-            size: na::Vector2::new(0.015, 0.015),
+            size: 0.015,
             friction: 0.5,
         };
 
@@ -270,19 +269,20 @@ fn scene(time: f32, dt: f32) -> Scene {
 }
 
 fn render_context(target_size: (u32, u32)) -> rendology::Context {
+    let projection = na::Perspective3::new(
+        target_size.0 as f32 / target_size.1 as f32,
+        60.0f32.to_radians(),
+        0.1,
+        1000.0,
+    )
+    .to_homogeneous();
     let camera = rendology::Camera {
         view: na::Matrix4::look_at_rh(
             &na::Point3::new(9.0, -5.0, 7.0),
             &na::Point3::new(0.0, 0.0, 0.0),
             &na::Vector3::new(0.0, 0.0, 1.0),
         ),
-        projection: na::Perspective3::new(
-            target_size.0 as f32 / target_size.1 as f32,
-            60.0f32.to_radians(),
-            0.1,
-            1000.0,
-        )
-        .to_homogeneous(),
+        projection,
         viewport_size: na::Vector2::new(target_size.0 as f32, target_size.1 as f32),
     };
 

--- a/examples/particles.rs
+++ b/examples/particles.rs
@@ -223,7 +223,7 @@ fn scene(time: f32, dt: f32) -> Scene {
 
     scene.lights.push(Light {
         position: na::Point3::new(10.0, 10.0, 10.0),
-        attenuation: na::Vector3::new(1.0, 0.0, 0.0),
+        attenuation: na::Vector4::new(1.0, 0.0, 0.0, 0.0),
         color: na::Vector3::new(1.0, 1.0, 1.0),
         is_main: true,
         ..Default::default()

--- a/src/instancing.rs
+++ b/src/instancing.rs
@@ -17,7 +17,7 @@ where
     V: glium::vertex::Vertex,
 {
     fn create<F: glium::backend::Facade>(facade: &F) -> Result<Self, CreationError> {
-        let buffer = glium::VertexBuffer::empty_dynamic(facade, INSTANCES_PER_BUFFER)?;
+        let buffer = glium::VertexBuffer::empty(facade, INSTANCES_PER_BUFFER)?;
 
         Ok(Self {
             buffer,
@@ -77,7 +77,7 @@ impl<I: InstanceInput> Instancing<I> {
         for buffer in &mut self.buffers {
             if buffer.num_used > 0 {
                 buffer.buffer.invalidate();
-                buffer.buffer = glium::VertexBuffer::empty_dynamic(facade, INSTANCES_PER_BUFFER)?;
+                buffer.buffer = glium::VertexBuffer::empty(facade, INSTANCES_PER_BUFFER)?;
                 buffer.clear();
             }
         }

--- a/src/instancing.rs
+++ b/src/instancing.rs
@@ -75,7 +75,11 @@ impl<I: InstanceInput> Instancing<I> {
         // Write instance data into vertex buffers. We move through the buffers
         // that we have, filling them up sequentially.
         for buffer in &mut self.buffers {
-            buffer.clear();
+            if buffer.num_used > 0 {
+                buffer.buffer.invalidate();
+                buffer.buffer = glium::VertexBuffer::empty_dynamic(facade, INSTANCES_PER_BUFFER)?;
+                buffer.clear();
+            }
         }
 
         let mut cur_buffer = 0;

--- a/src/instancing.rs
+++ b/src/instancing.rs
@@ -5,7 +5,7 @@ use crate::{Drawable, Mesh};
 
 pub use crate::error::{CreationError, DrawError};
 
-pub const INSTANCES_PER_BUFFER: usize = 1000;
+pub const INSTANCES_PER_BUFFER: usize = 10000;
 
 struct Buffer<V: Copy> {
     buffer: glium::VertexBuffer<V>,

--- a/src/particle/mod.rs
+++ b/src/particle/mod.rs
@@ -30,7 +30,7 @@ struct Buffer {
 
 impl Buffer {
     fn create<F: glium::backend::Facade>(facade: &F, size: usize) -> Result<Self, CreationError> {
-        let buffer = glium::VertexBuffer::empty_dynamic(facade, size)?;
+        let buffer = glium::VertexBuffer::empty(facade, size)?;
 
         Ok(Self {
             buffer,
@@ -88,12 +88,17 @@ impl System {
             .map(|_| Buffer::create(facade, config.particles_per_buffer))
             .collect::<Result<Vec<_>, _>>()?;
 
-        Ok(Self {
+        let mut system = Self {
             config: config.clone(),
             buffers,
             next_index: (0, 0),
             current_time: 0.0,
-        })
+        };
+
+        // Make sure to initialize buffer memory
+        system.clear();
+
+        Ok(system)
     }
 
     pub fn shader(&self) -> Shader {

--- a/src/particle/mod.rs
+++ b/src/particle/mod.rs
@@ -48,8 +48,8 @@ pub struct Config {
 impl Default for Config {
     fn default() -> Self {
         Self {
-            particles_per_buffer: 20000,
-            num_buffers: 30,
+            particles_per_buffer: 10000,
+            num_buffers: 100,
         }
     }
 }
@@ -105,6 +105,9 @@ impl System {
     }
 
     pub fn spawn(&mut self, mut particles: &[<Particle as InstanceInput>::Vertex]) {
+        /*self.next_index.0 = (self.next_index.0 + 1) % self.buffers.len();
+        self.next_index.1 = 0;*/
+
         // Copy new particles, filling up the ring buffer.
         while !particles.is_empty() {
             // By our invariant, `self.next_index` always is valid.

--- a/src/particle/mod.rs
+++ b/src/particle/mod.rs
@@ -131,6 +131,7 @@ impl System {
                 .iter()
                 .map(|particle| particle.particle_spawn_time + particle.particle_life_duration)
                 .fold(0.0, f32::max);
+            assert!(!new_max_death_time.is_nan());
 
             target_buffer.max_death_time = target_buffer.max_death_time.max(new_max_death_time);
 

--- a/src/particle/scene.rs
+++ b/src/particle/scene.rs
@@ -115,7 +115,6 @@ const VERTEX_SHADER: &str = "
         vec3 current_pos = particle_start_pos
             + particle_velocity * delta_time
             - 0.5 * particle_friction * delta_time * delta_time * normalize(particle_velocity);
-        //vec3 current_pos = particle_start_pos;
         gl_Position = context_camera_view * vec4(current_pos, 1);
 
         // Forward particle properties to geometry shader.
@@ -167,6 +166,8 @@ const GEOMETRY_SHADER: &str = "
             vertex_out.color = vertex_in[0].color;
             vertex_out.uv = vec2(1, 1);
             EmitVertex();
+
+            EndPrimitive();
         }
     }
 ";

--- a/src/particle/scene.rs
+++ b/src/particle/scene.rs
@@ -22,7 +22,7 @@ pub struct Particle {
     pub start_pos: na::Point3<f32>,
     pub velocity: na::Vector3<f32>,
     pub color: na::Vector3<f32>,
-    pub size: na::Vector2<f32>,
+    pub size: f32,
     pub friction: f32,
 }
 
@@ -34,7 +34,7 @@ impl Particle {
             start_pos: na::Point3::origin(),
             velocity: na::Vector3::zeros(),
             color: na::Vector3::zeros(),
-            size: na::Vector2::zeros(),
+            size: 0.0,
             friction: 0.0,
         }
     }
@@ -48,7 +48,7 @@ impl_instance_input!(
         particle_start_pos: [f32; 3] = self.start_pos.coords,
         particle_velocity: [f32; 3] = self.velocity,
         particle_color: [f32; 3] = self.color,
-        particle_size: [f32; 2] = self.size,
+        particle_size: f32 = self.size,
         particle_friction: f32 = self.friction,
     },
 );
@@ -70,9 +70,13 @@ impl BuildProgram for Shader {
     ) -> Result<glium::Program, glium::program::ProgramCreationError> {
         // We use the long form of `glium::Program` here to set `outputs_rgb`
         // to true. See `shader::LinkedCore::build_program` for more background.
+        // Here, we additionally set `uses_point_size` to true.
         glium::Program::new(
             facade,
             glium::program::ProgramCreationInput::SourceCode {
+                /*vertex_shader: VERTEX_SHADER_2,
+                fragment_shader: FRAGMENT_SHADER_2,
+                geometry_shader: None,*/
                 vertex_shader: VERTEX_SHADER,
                 fragment_shader: FRAGMENT_SHADER,
                 geometry_shader: Some(GEOMETRY_SHADER),
@@ -88,7 +92,6 @@ impl BuildProgram for Shader {
 
 const VERTEX_SHADER: &str = "
     #version 330
-
     uniform mat4 context_camera_view;
     uniform float params_time;
 
@@ -97,12 +100,12 @@ const VERTEX_SHADER: &str = "
     in vec3 particle_start_pos;
     in vec3 particle_velocity;
     in vec3 particle_color;
-    in vec2 particle_size;
+    in float particle_size;
     in float particle_friction;
 
     out VertexData {
         vec4 color;
-        vec2 size;
+        float size;
     } vertex_out;
 
     void main() {
@@ -111,7 +114,8 @@ const VERTEX_SHADER: &str = "
         // Integrate velocity.
         vec3 current_pos = particle_start_pos
             + particle_velocity * delta_time
-            - 0.5 * particle_friction * delta_time * delta_time * normalize(particle_velocity); 
+            - 0.5 * particle_friction * delta_time * delta_time * normalize(particle_velocity);
+        //vec3 current_pos = particle_start_pos;
         gl_Position = context_camera_view * vec4(current_pos, 1);
 
         // Forward particle properties to geometry shader.
@@ -130,7 +134,7 @@ const GEOMETRY_SHADER: &str = "
 
     in VertexData {
         vec4 color;
-        vec2 size;
+        float size;
     } vertex_in[];
 
     out VertexData {
@@ -142,24 +146,24 @@ const GEOMETRY_SHADER: &str = "
         // If the particle is alive, generate a camera-aligned quad.
         if (vertex_in[0].color.a > 0.0 && vertex_in[0].color.a <= 1.0) {
             vec4 center = gl_in[0].gl_Position;
-            vec2 size = vertex_in[0].size * vertex_in[0].color.a;
+            float size = vertex_in[0].size * vertex_in[0].color.a;
 
-            gl_Position = context_camera_projection * (center + vec4(-size.x, -size.y, 0, 0));
+            gl_Position = context_camera_projection * (center + vec4(-size, -size, 0, 0));
             vertex_out.color = vertex_in[0].color;
             vertex_out.uv = vec2(-1, -1);
             EmitVertex();
 
-            gl_Position = context_camera_projection * (center + vec4(size.x, -size.y, 0, 0));
+            gl_Position = context_camera_projection * (center + vec4(size, -size, 0, 0));
             vertex_out.color = vertex_in[0].color;
             vertex_out.uv = vec2(1, -1);
             EmitVertex();
 
-            gl_Position = context_camera_projection * (center + vec4(-size.x, size.y, 0, 0));
+            gl_Position = context_camera_projection * (center + vec4(-size, size, 0, 0));
             vertex_out.color = vertex_in[0].color;
             vertex_out.uv = vec2(-1, 1);
             EmitVertex();
 
-            gl_Position = context_camera_projection * (center + vec4(size.x, size.y, 0, 0));
+            gl_Position = context_camera_projection * (center + vec4(size, size, 0, 0));
             vertex_out.color = vertex_in[0].color;
             vertex_out.uv = vec2(1, 1);
             EmitVertex();
@@ -179,8 +183,68 @@ const FRAGMENT_SHADER: &str = "
 
     void main() {
         float circle = max(1 - dot(vertex_in.uv, vertex_in.uv), 0);
-
         target = vertex_in.color;
         target.a *= circle;
     }
 ";
+
+// The below version does not use a geometry shader, instead relying on
+// `GL_POINTS`. It is not finished, since it does not correct the
+// `gl_PointSize` for perspective.
+//
+// Unfortunately, it is not significantly faster than using the geometry shader
+// on my GPU (NVIDIA GTX 1070).
+/*
+const VERTEX_SHADER_2: &str = "
+    #version 330
+
+    uniform mat4 context_camera_view;
+    uniform mat4 context_camera_projection;
+    uniform float params_time;
+
+    in float particle_spawn_time;
+    in float particle_life_duration;
+    in vec3 particle_start_pos;
+    in vec3 particle_velocity;
+    in vec3 particle_color;
+    in float particle_size;
+    in float particle_friction;
+
+    out vec4 v_color;
+
+    void main() {
+        float delta_time = params_time - particle_spawn_time;
+
+        if (delta_time >= 0.0 && delta_time <= particle_life_duration) {
+            v_color = vec4(particle_color, 1.0 - pow(delta_time / particle_life_duration, 3.0));
+
+            // Integrate velocity together with friction.
+            vec3 current_pos = particle_start_pos
+                + particle_velocity * delta_time
+                - 0.5 * particle_friction * delta_time * delta_time * normalize(particle_velocity);
+            gl_Position = context_camera_projection * context_camera_view * vec4(current_pos, 1);
+            //gl_Position.z -= 100.0 * float(delta_time < 0.0 || delta_time > particle_life_duration);
+
+            //gl_PointSize = particle_size * 3.0 * (1.0 - v_color.a) / gl_Position.w;
+            gl_PointSize = 0.1;
+        } else {
+            gl_Position = vec4(100.0, 100.0, 100.0, -100.0);
+        }
+    }
+";
+
+const FRAGMENT_SHADER_2: &str = "
+    #version 330
+
+    in vec4 v_color;
+    out vec4 f_color;
+
+    void main() {
+        vec2 uv = gl_PointCoord;
+        float circle = max(1 - dot(uv, uv), 0);
+
+        f_color = v_color;
+        f_color.a *= circle;
+    }
+";
+*/

--- a/src/particle/scene.rs
+++ b/src/particle/scene.rs
@@ -140,7 +140,7 @@ const GEOMETRY_SHADER: &str = "
 
     void main() {
         // If the particle is alive, generate a camera-aligned quad.
-        if (vertex_in[0].color.a > 0.0) {
+        if (vertex_in[0].color.a > 0.0 && vertex_in[0].color.a <= 1.0) {
             vec4 center = gl_in[0].gl_Position;
             vec2 size = vertex_in[0].size * vertex_in[0].color.a;
 

--- a/src/particle/scene.rs
+++ b/src/particle/scene.rs
@@ -115,7 +115,7 @@ const VERTEX_SHADER: &str = "
         gl_Position = context_camera_view * vec4(current_pos, 1);
 
         // Forward particle properties to geometry shader.
-        vertex_out.color = vec4(particle_color, 1.0 - pow(delta_time / particle_life_duration, 10.0));
+        vertex_out.color = vec4(particle_color, 1.0 - pow(delta_time / particle_life_duration, 3.0));
         vertex_out.size = particle_size;
     }
 ";
@@ -142,7 +142,7 @@ const GEOMETRY_SHADER: &str = "
         // If the particle is alive, generate a camera-aligned quad.
         if (vertex_in[0].color.a > 0.0) {
             vec4 center = gl_in[0].gl_Position;
-            vec2 size = vertex_in[0].size;
+            vec2 size = vertex_in[0].size * vertex_in[0].color.a;
 
             gl_Position = context_camera_projection * (center + vec4(-size.x, -size.y, 0, 0));
             vertex_out.color = vertex_in[0].color;

--- a/src/pipeline/deferred/mod.rs
+++ b/src/pipeline/deferred/mod.rs
@@ -9,7 +9,7 @@ use log::info;
 
 use nalgebra as na;
 
-use glium::{uniform, Surface, Texture2d};
+use glium::{Surface, Texture2d};
 
 use crate::shader::{self, InstanceInput, ToUniforms};
 use crate::{

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -369,7 +369,12 @@ impl<'a, F: glium::backend::Facade, S: Surface> ShadedScenePassStep<'a, F, S> {
         if let Some(deferred_shading) = components.deferred_shading.as_mut() {
             profile!("light_pass");
 
-            deferred_shading.light_pass(self.0.facade, &self.0.context.camera, lights)?;
+            deferred_shading.light_pass(
+                self.0.facade,
+                &pipeline.scene_depth_texture,
+                &self.0.context.camera,
+                lights,
+            )?;
         }
 
         // Blur the glow texture

--- a/src/stage.rs
+++ b/src/stage.rs
@@ -24,7 +24,7 @@ impl_uniform_input!(
 #[derive(Debug, Clone)]
 pub struct Light {
     pub position: na::Point3<f32>,
-    pub attenuation: na::Vector3<f32>,
+    pub attenuation: na::Vector4<f32>,
     pub color: na::Vector3<f32>,
     pub is_main: bool,
     pub radius: f32,
@@ -34,9 +34,8 @@ impl_instance_input!(
     Light,
     self => {
         light_position: [f32; 3] = self.position.coords,
-        light_attenuation: [f32; 3] = self.attenuation,
+        light_attenuation: [f32; 4] = self.attenuation,
         light_color: [f32; 3] = self.color,
-        //light_is_main: Bool = self.is_main,
         light_radius: f32 = self.radius,
     },
 );
@@ -45,7 +44,7 @@ impl Default for Light {
     fn default() -> Self {
         Self {
             position: na::Point3::origin(),
-            attenuation: na::Vector3::zeros(),
+            attenuation: na::Vector4::zeros(),
             color: na::Vector3::zeros(),
             is_main: false,
             radius: 0.0,


### PR DESCRIPTION
- Specify better usage flags for `glium` buffers. Apparently `glium::buffer::BufferMode::Dynamic` causes the buffer to get `GL_CLIENT_STORAGE_BIT`, which is super slow for me. With this fix, I can now easily render 3M particles instead of just 300K.
- Deferred shading:
  - Depth test for light pass
  - Allow specifying exponential attenuation for light sources, which means smaller light radii
  - Discard in light fragment shader to avoid additive blending overhead

I've also experimented with avoiding the geometry shader for particles, but no success yet in terms of performance.