### PR TITLE
Updates glium dependency to 0.30

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 
 [dependencies]
 nalgebra = "0.18"
-glium = "0.25"
+glium = "0.30"
 log = "0.4"
 glsl = "3.0"
 num-traits = "0.2"

--- a/examples/lines.rs
+++ b/examples/lines.rs
@@ -1,7 +1,16 @@
 use std::time::Instant;
 
 use floating_duration::TimeAsFloat;
-use glium::{glutin, Surface};
+use glium::{
+    glutin::{
+        self,
+        dpi::PhysicalSize,
+        event::{Event, WindowEvent},
+        event_loop::{ControlFlow, EventLoop},
+        window::WindowBuilder,
+    },
+    Surface
+};
 use nalgebra as na;
 
 use rendology::{
@@ -116,10 +125,10 @@ fn main() {
     simple_logger::init_with_level(log::Level::Info).unwrap();
 
     // Initialize glium
-    let mut events_loop = glutin::EventsLoop::new();
+    let events_loop = EventLoop::new();
     let display = {
-        let window_builder = glutin::WindowBuilder::new()
-            .with_dimensions(WINDOW_SIZE.into())
+        let window_builder = WindowBuilder::new()
+            .with_inner_size(PhysicalSize::new(WINDOW_SIZE.0, WINDOW_SIZE.1))
             .with_title("Rendology example: Cube");
         let context_builder = glutin::ContextBuilder::new();
         glium::Display::new(window_builder, context_builder, &events_loop).unwrap()
@@ -129,17 +138,19 @@ fn main() {
     let mut pipeline = Pipeline::create(&display, &Default::default()).unwrap();
 
     let start_time = Instant::now();
-    let mut quit = false;
-    while !quit {
-        events_loop.poll_events(|event| {
-            if let glutin::Event::WindowEvent {
-                event: glutin::WindowEvent::CloseRequested,
-                ..
-            } = event
-            {
-                quit = true;
-            }
-        });
+    events_loop.run(move |event, _, control_flow| {
+        *control_flow = ControlFlow::Poll;
+        match event {
+            Event::LoopDestroyed => return,
+            Event::WindowEvent { event, .. } => match event {
+                WindowEvent::CloseRequested => {
+                    *control_flow = ControlFlow::Exit;
+                    return
+                },
+                _ => (),
+            },
+            _ => (),
+        }
 
         let time = start_time.elapsed().as_fractional_secs() as f32;
         let scene = scene(time);
@@ -152,7 +163,7 @@ fn main() {
             .unwrap();
 
         target.finish().unwrap();
-    }
+    });
 }
 
 fn scene(time: f32) -> Scene {


### PR DESCRIPTION
This change updates to the latest version of glium (0.30), which brings
glutin to version 0.27 and winit to 0.25. This fixes known issue
[#1773](https://github.com/rust-windowing/winit/issues/1773) in winit
0.19 on Linux X11.

The key stubstanitive change to the examples is the change from glutin's
`EventsLoop` to `EventLoop`. Instead of a user-defined while loop where
`EventsLoop::poll_events` is called, `EventLoop` has switched to a run
function which is event-driven by glutin's core. This slightly changes
the program structure.

The other changes are minor, as glutin moved a few data structures into
modules instead of having everything visible at the top-level.